### PR TITLE
Change/add vaginalpullout action tag to pullout animations

### DIFF
--- a/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Po/AceMissionaryLegsHeld_MaleClimaxPullOutJO.xml
+++ b/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Po/AceMissionaryLegsHeld_MaleClimaxPullOutJO.xml
@@ -2,7 +2,7 @@
 <info name="Missionary Pull Out JO" animator="Ace"/>
 <region om="A" maj="C" min="C" stage="" step="" story=""/>
 <anim id="_Po-AceMissionaryLegsHeld_MaleClimaxPullOutJO" t="L" l="2"/>
-<speed a="0" min="0" max="1" name="thrusts">	
+<speed a="0" min="0" max="1" name="thrusts">
 	<sp mtx="^thrustsPerSec" qnt="3">
 		<anim id="_Po-AceMissionaryLegsHeld_MaleClimaxPullOutJO" t="L" l="2" i0="0" i1="0"/></sp>
 	<sp mtx="^thrustsPerSec" qnt="3">
@@ -27,6 +27,6 @@
 	<actor position="1" feetOnGround="0" tags="lyingback" lookUp="-40"/>
 </actors>
 <actions>
-	<action type="malemasturbation" actor="0"/>
+	<action type="vaginalpullout" actor="0"/>
 </actions>
 </scene>

--- a/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Po/AceMissionaryLegsHeld_PullOutGoBack.xml
+++ b/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Po/AceMissionaryLegsHeld_PullOutGoBack.xml
@@ -6,4 +6,7 @@
 	<actor position="0" feetOnGround="0" tags="kneeling" lookUp="-25"/>
 	<actor position="1" feetOnGround="0" tags="lyingback" lookUp="-40"/>
 </actors>
+<actions>
+	<action type="vaginalpullout" actor="0"/>
+</actions>
 </scene>

--- a/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Sx/AceMissionaryLegsHeld_PullOut.xml
+++ b/meshes/0SA/mod/0Sex/scene/OpS/KneLyB/Sx/AceMissionaryLegsHeld_PullOut.xml
@@ -6,4 +6,7 @@
 	<actor position="0" penisAngle="2" feetOnGround="0" tags="kneeling" lookUp="-25"/>
 	<actor position="1" feetOnGround="0" tags="lyingback" lookUp="-40"/>
 </actors>
+<actions>
+	<action type="vaginalpullout" actor="0"/>
+</actions>
 </scene>


### PR DESCRIPTION
Pullout animations were tagged as "malemasturbation" which wasn't descriptive enough for OStim addons like OCum Ascended.

Changed them to "vaginalpullout" so it's more precise.